### PR TITLE
Add hands-on labs to crack the code section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1062,6 +1062,7 @@ Challenges and learning platforms about cyber security and ethical hacking.
 | [Hack This Site](https://www.hackthissite.org) | Training ground for ethical hacking with challenges, CTFs, and more. | `Website` |
 | [Cyberseek](https://www.cyberseek.org) | Explore career paths, skills, and certifications in cyber security. | `Website` |
 | [Advent of Code](https://adventofcode.com) | Christmas-themed programming challenges following an Advent calendar. | `Website` |
+| [LabEx](https://labex.io/skilltrees/cybersecurity) | Hands-on labs for cyber security, covering tools like Nmap, Wireshark, Kali, and more. | `Website` |
 
 ----
 


### PR DESCRIPTION
Add LabEx cybersecurity labs to crack the code section

I work at LabEx, a unique learning platform that has delivered thousands of hands-on labs over the past 7 years. Our Cybersecurity Skill Tree currently offers 34 foundational skills and 80 hands-on labs, making it perfect for beginners to learn cybersecurity step by step. 

This repo is a great resource. Please let me know if any changes are needed.