### PR TITLE
Add 42 PeerFinder

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Websites that I found useful in my 42 journey.
 | [42 XP Calculator](https://42.tbailleu.dev) | Calculate how much exp you need for the next level.        | `Website` |
 | [Find Peers](https://find-peers.codam.nl)   | Find peers working on the same project.                    | `Website` |
 | [S42](https://s42.app)                      | Clusters from various 42 schools.                          | `Website` |
+| [42 PeerFinder](https://42peerfinder.com/)  | List of online students and cluster maps.                  | `Website` |
 
 ----
 


### PR DESCRIPTION
I added [42 PeerFinder](https://42peerfinder.com/) which shows a list of online students of the user's campus and cluster maps for supported capuses.

Spoiler: I'm the creator of the tool, so feel free to add it only if you like it.